### PR TITLE
changed channel naming to support channel wildcards

### DIFF
--- a/botkit/plugin/plugin-pubnub.js
+++ b/botkit/plugin/plugin-pubnub.js
@@ -20,7 +20,7 @@ class PubnubBotkit {
 
     debug("Subscribing...");
     pubnub.subscribe({
-      channels: ['webex-all-all']
+      channels: ['webex.*']
     });
   }
 

--- a/botkit/sample-application/components/plugin-pubnub.js
+++ b/botkit/sample-application/components/plugin-pubnub.js
@@ -20,7 +20,7 @@ class PubnubBotkit {
 
     debug("Subscribing...");
     pubnub.subscribe({
-      channels: ['webex-all-all']
+      channels: ['webex.*']
     });
   }
 

--- a/monitor.js
+++ b/monitor.js
@@ -33,5 +33,5 @@ pubnub.addListener({
 
 console.log("Subscribing...");
 pubnub.subscribe({
-  channels: ['webex-messages-created', 'webex-messages-all', 'webex-all-all']
+  channels: ['webex.messages.created', 'webex.messages.*', 'webex.*']
 });

--- a/pubnub-function.js
+++ b/pubnub-function.js
@@ -22,12 +22,11 @@ export default (request, response) => {
 
   let payload = JSON.parse(request.body);
 
-  return Promise.all([
-    publish(`webex-${payload.resource}-${payload.event}`, request.body),
-    publish(`webex-${payload.resource}all`, request.body),
-    publish(`webex-all-all`, request.body)
-  ])
-    .then(results => {
+  // this is just as good as your previous idea since I can subescribe to
+  // webex.*
+  // webex.memberships.*
+  // webex.memberships.created
+  publish(`webex.${payload.resource}.${payload.event}`, request.body).then(results => {
       return response.send("Published");
     })
     .catch(err => {


### PR DESCRIPTION
In your code your are publishing to 3 channels in the PubNub function. For example these would be for an event resource:memberships and event:created the following 3 channels
webex-all-all webex-memberships-all and webex.memberships.created

A client would subscribe to webex.memberships.created if only interested in memberships created events
or webex-memberships-all for all membership events
or 
webex-all-all for any webex event 


I think my approach gives you the same. If you want all webex events you subscribe to webex.* all membership events to webex.memberships.* or a specific membership event webex.memberships.created